### PR TITLE
Fix Multiple dex files error

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -12,5 +12,5 @@ repositories {
 dependencies {
     compile 'me.leolin:ShortcutBadger:1.1.4@aar'
     compile 'com.google.firebase:firebase-crash:+'
-    compile 'com.google.firebase:firebase-auth:11.0.0'
+    compile 'com.google.firebase:firebase-auth:+'
 }


### PR DESCRIPTION
This fixes the error I mentioned in the comment on your pull request

Error message:
```
Execution failed for task ':transformClassesWithDexForDebug'.
> com.android.build.api.transform.TransformException: com.android.ide.common.process.ProcessException: java.util.concurrent.ExecutionException: com.android.dex.DexException: Multiple dex files define Lcom/google/android/gms/internal/ma;
```